### PR TITLE
implement idle timer when user isn't moving the mouse or typing

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,33 @@ canAddComment(isLoggedIn, fromHomepage) {
 {{/if}}
 ```
 
+### Idle Timer
+
+Code for making an idle timer that's called in the `comment.js`, `post.js`, and `update-post.js` files.
+```js
+function setupIdleTimer() {
+    let count = IDLE_TIME;
+    const timer = setInterval(async () => {
+        if (count === 0) {
+            clearInterval(timer);
+
+            await fetch("/api/users/logout", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+            });
+
+            document.location.reload();
+            return;
+        } else {
+            count--;
+        }
+
+    }, COUNTDOWN_INTERVAL);
+}
+```
+
 ## Images
 
 Homepage on desktop screen

--- a/public/js/comment.js
+++ b/public/js/comment.js
@@ -1,3 +1,7 @@
+import { setupIdleTimer } from "./idle-timer.js";
+
+setupIdleTimer();
+
 async function toggleAddComment(event, addComment) {
     event.preventDefault();
     event.stopPropagation();
@@ -10,7 +14,6 @@ async function toggleAddComment(event, addComment) {
     if (addComment) {
         document.getElementById("form-comment").scrollIntoView();
     }
-    
 }
 
 
@@ -54,9 +57,24 @@ async function addComment(event) {
     }
 }
 
-
 document.querySelector("#button-make-comment").addEventListener("click", (event) => toggleAddComment(event, true));
 document.querySelector("#button-cancel-comment").addEventListener("click", (event) => toggleAddComment(event, false));
 document.querySelector("#button-add-comment").addEventListener("click", addComment);
 
-console.log("HELLO FROM COMMENT.JS")
+
+// Make event listeners to check if user is idle or not.
+// Idle means not moving the mouse or typing. That way the page won't refresh while the user is doing something
+document.addEventListener("mousemove", (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    
+    // console.log("@update-post document body mouse move");
+    setupIdleTimer();
+})
+
+document.addEventListener("keydown", (e) => {
+    e.stopPropagation();
+
+    // console.log("@update-post document body keydown");
+    setupIdleTimer();
+})

--- a/public/js/idle-timer.js
+++ b/public/js/idle-timer.js
@@ -1,0 +1,29 @@
+const IDLE_TIME = 60 * 60; // How many seconds until a user is logged out when just sitting idle on the website
+const COUNTDOWN_INTERVAL = 1000; // 1 second
+
+export function setupIdleTimer() {
+    // console.log("setup idle timer for", IDLE_TIME, "seconds");
+    // console.log("counds down every", COUNTDOWN_INTERVAL, "milliseconds")
+
+    let count = IDLE_TIME;
+    const timer = setInterval(async () => {
+        if (count === 0) {
+            console.log("idle time reached");
+            clearInterval(timer);
+
+            await fetch("/api/users/logout", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+            });
+
+            document.location.reload();
+            return;
+        } else {
+            count--;
+            // console.log("req.session.idleTimer:", count);
+        }
+
+    }, COUNTDOWN_INTERVAL);
+}

--- a/public/js/post.js
+++ b/public/js/post.js
@@ -1,3 +1,7 @@
+import { setupIdleTimer } from "./idle-timer.js";
+
+setupIdleTimer();
+
 function toggleNewPost(event, makeNewPost) {
     event.preventDefault();
     event.stopPropagation();
@@ -47,3 +51,20 @@ async function addNewPost(event) {
 document.querySelector("#button-make-post").addEventListener("click", (event) => toggleNewPost(event, true));
 document.querySelector("#button-cancel-post").addEventListener("click", (event) => toggleNewPost(event, false));
 document.querySelector("#button-add-post").addEventListener("click", addNewPost);
+
+// Make event listeners to check if user is idle or not.
+// Idle means not moving the mouse or typing. That way the page won't refresh while the user is doing something
+document.addEventListener("mousemove", (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    
+    // console.log("@update-post document body mouse move");
+    setupIdleTimer();
+})
+
+document.addEventListener("keydown", (e) => {
+    e.stopPropagation();
+
+    // console.log("@update-post document body keydown");
+    setupIdleTimer();
+})

--- a/public/js/update-post.js
+++ b/public/js/update-post.js
@@ -1,3 +1,7 @@
+import { setupIdleTimer } from "./idle-timer.js";
+
+setupIdleTimer();
+
 function toggleEditPost(event, updatePost) {
     event.preventDefault();
     event.stopPropagation();
@@ -99,3 +103,21 @@ document.querySelector("#button-cancel-update").addEventListener("click", (event
 document.querySelector("#button-confirm-update").addEventListener("click", updatePost);
 
 document.querySelector("#button-delete-post").addEventListener("click", promptForDelete);
+
+
+// Make event listeners to check if user is idle or not.
+// Idle means not moving the mouse or typing. That way the page won't refresh while the user is doing something
+document.addEventListener("mousemove", (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    
+    // console.log("@update-post document body mouse move");
+    setupIdleTimer();
+})
+
+document.addEventListener("keydown", (e) => {
+    e.stopPropagation();
+
+    // console.log("@update-post document body keydown");
+    setupIdleTimer();
+})

--- a/views/dashboard.handlebars
+++ b/views/dashboard.handlebars
@@ -12,4 +12,4 @@
 
 </section>
 
-<script src="./js/post.js"></script>
+<script type="module" src="./js/post.js"></script>

--- a/views/post.handlebars
+++ b/views/post.handlebars
@@ -37,9 +37,9 @@
 
 {{!-- Decide which file to load --}}
 {{#if (canAddPost loggedIn fromDashboard)}}
-<script src="../../js/update-post.js"></script>
+<script type="module" src="../../js/update-post.js"></script>
 {{/if}}
 
 {{#if (canAddComment loggedIn fromHomepage)}}
-<script src="../../js/comment.js"></script>
+<script type="module" src="../../js/comment.js"></script>
 {{/if}}


### PR DESCRIPTION
- implement idle timer. Once timer hits 0, it calls the `/api/users/logout` endpoint and then refreshes the page.
- As of this commit, the idle timer is set for 1 hour (in seconds).
- The timer is reset on any mouse movement or keydown event. This is to prevent the timer from hitting 0 if the user is doing something important like making a new comment or post